### PR TITLE
about/rse.rst: Add comments indicating an equal focus on data

### DIFF
--- a/about/rse.rst
+++ b/about/rse.rst
@@ -37,17 +37,20 @@ include:
 
 * Setting up a project in version control with all the features.  This
   also includes version control of data.
-* Creating or automating a workflow, especially using data
-* Optimizing some code
-* Efficiency storing data for intensive analysis
 * Preparing code or data for release and publication
-* Making existing software more modular
+* Creating or automating a workflow, especially those processing data
+  or running simulations
+* Optimizing some code - both for speed and/or adaptability
+* Efficiency storing data for intensive analysis.  Data replication
+  and management.
+* Making existing software more modular and reusable
 * Help properly using, for example, machine learning library
-  pipelines
+  pipelines, instead of hacking things together yourself
 * Setting up automatic software testing
-* Transforming projects from individual to collaborative.
+* Transforming projects from individual to collaborative - either
+  within a group, or open source.
 * Generalized "code clean-up" which takes a project from development
-  to stablalized
+  to stabilized
 
 **Dedicated service:** Our RSEs may also provide
 programming-as-a-service for specific projects.  Normally, this would
@@ -55,7 +58,8 @@ be for larger projects which need long-term support and maintenance,
 including those which just want a service and not necessarily to learn
 how to do it themselves.  As part of this service, one can get:
 
-* Developing or maintaining specific software or services.
+* Developing or maintaining specific software, services, demos, or
+  implementations.
 * Software support that lasts beyond the time frame of a single
   student's attention
 * Software development as a service

--- a/about/rse.rst
+++ b/about/rse.rst
@@ -1,11 +1,12 @@
 Research Software Engineers
 ===========================
 
-In 2020, Aalto Scientific Computing is trialing a Research Software
+In 2020, Aalto Scientific Computing is trialing a Research Software/Data
 Engineer (RSE) program to improve the quality of our scientific
-computing.  "`Research software engineer <rse-def_>`_" is a recent
+computing and data use.  "`Research software engineer <rse-def_>`_" is a recent
 term for a longstanding role: someone that works at the interface of
-research and software development, but not fully either.
+research and software development, but not fully either.  We think
+this applies equally to data.
 
 .. _rse-def: https://rse.ac.uk/who/
 
@@ -21,23 +22,25 @@ subject to change.**
 For researchers
 ---------------
 
-You program in your daily work, and you know something is missing:
-your code is less organized, less efficient, less managed than others,
+You program or anylyze data in your daily work, and you know something is missing:
+your code and data is less organized, less efficient, less managed than others,
 and it's affecting the quality of your work.  Or maybe you don't know
 how to start your project, or publish it.  You're too busy with the
-science to have time to focus on the software.
+science to have time to focus on the computing.
 
-**Basic service:** You can apply to the Research Software Engineer
+**Basic service:** You can apply to the Research Software/Data Engineer
 (RSE) program for support and mentorship.  One of our trained RSEs
 will work with you for a short period to begin or improve your
 project.  The goal is not just to do it for you, but to show you by
 example so that you can do it yourself later.  Typical basic tasks
 include:
 
-* Setting up a project in version control with all the features
-* Automating a workflow
+* Setting up a project in version control with all the features.  This
+  also includes version control of data.
+* Creating or automating a workflow, especially using data
 * Optimizing some code
-* Preparing code for release and publication
+* Efficiency storing data for intensive analysis
+* Preparing code or data for release and publication
 * Making existing software more modular
 * Help properly using, for example, machine learning library
   pipelines


### PR DESCRIPTION
- I got a comment that the page doesn't emphasize data enough - and
  this is true.  I addded some.
- I left the name "Research Software Engineer" in most places, but in
  the introduction put "Research Software/Date Engineer".  It should
  be clarified, any thoughts on this?
- Anything more to add here?