### PR TITLE
about/rse.rst: Add sentence describing relation to other training

### DIFF
--- a/about/rse.rst
+++ b/about/rse.rst
@@ -14,6 +14,12 @@ A basic service is provided for certain departments, and an dedicated
 service for groups who provide their own funding.  Departments/school
 and groups can co-fund the program to gain a dedicated share.
 
+This is the hands-on compliment our training programs, mainly
+:doc:`scientific computing in practice sessions </training/scip>` and
+`CodeRefinery <https://coderefinery.org>`_.  If you want a kickstart
+to put those sessons in practice, this is for you.  Attendance
+in these courses is useful but by no means required.
+
 **This is draft information about a pilot project, information is
 subject to change.**
 


### PR DESCRIPTION
- We should connect RSEs to our courses, and emphasize that this is a
  hands-on kickstart.