### PR TITLE
Triton: begin revising for anaconda3->anaconda

### DIFF
--- a/aalto/jupyterhub-data.rst
+++ b/aalto/jupyterhub-data.rst
@@ -115,12 +115,15 @@ the Jupyter data directories - they are for notebooks and small-medium
 data.)
 
 Using the built-in anaconda, you can load the Python modules with
-``module load anaconda3`` and start Jupyter with ``jupyter notebook``:
+``module load anaconda`` and start Jupyter with ``jupyter notebook``:
 
 .. figure:: /images/jupyterdata_04_startjupyter.png
 	    :scale: 75%
 	    :align: center
-	    :alt: Start jupyter with the anaconda3 module.
+	    :alt: Start jupyter with the anaconda module.
+
+	    Note that now, you need to ``module load anaconda``, not
+	    anaconda\ **3** like the image shows.
 
 
 

--- a/aalto/linux.rst
+++ b/aalto/linux.rst
@@ -168,7 +168,7 @@ Software
 
 Already available
 ~~~~~~~~~~~~~~~~~
-- Python: ``module load anaconda3`` (or anaconda2) (desktops)
+- Python: ``module load anaconda`` (or anaconda2 for Python 2) (desktops)
 - Matlab: automatically installed on desktops, Ubuntu package
   on laptops.
 
@@ -209,7 +209,7 @@ environment variables, so this needs to be repeated in each new shell
 
 Useful modules:
 
--  ``anaconda3`` and ``anaconda2`` will always be kept up to date with the latest Python
+-  ``anaconda`` and ``anaconda2`` will always be kept up to date with the latest Python
    Anaconda distribution, and we'll try to keep this in sync across
    Aalto Linux and Triton.
 

--- a/aalto/paniikki.rst
+++ b/aalto/paniikki.rst
@@ -82,9 +82,9 @@ base software that covers most people's needs.
 
    What?  |  How?
 
-   Python via Anaconda | ``module load anaconda3`` (anaconda3 for Python3)
+   Python via Anaconda | ``module load anaconda``
    Python (system) | Default available
-   Tensorflow | in the Python environments, e.g. anaconda3 above
+   Tensorflow | in the Python environments, e.g. anaconda above
 
 
 Modules
@@ -138,11 +138,12 @@ libraries.
 
 .. code-block:: bash
 
-   # Latest Python 2
+   # Latest Python 3
+   $ module load anaconda
+
+   # Old Python 2
    $ module load anaconda2
 
-   # Latest Python 3
-   $ module load anaconda3
 
 Example 3: List all software
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^

--- a/aalto/python.rst
+++ b/aalto/python.rst
@@ -3,7 +3,8 @@ Python
 ======
 
 The scientific python ecosystem is also available on Aalto Linux
-workstations, including the anaconda2 and anaconda3 modules providing
+workstations, including the anaconda (Python 3) and anaconda2
+(Python2) modules providing
 the Anaconda python distribution. For a more indepth description see
 the generic `python page under scientific computing docs
 </scicomp/python>`.

--- a/aalto/remotejupyter.rst
+++ b/aalto/remotejupyter.rst
@@ -30,7 +30,7 @@ Aalto provides two “light computing” servers: ``brute.org.aalto.fi``, ``forc
 	tmux
 
 	# Load Anaconda
-	module use /work/modules/modulefiles/common/; module refresh; module load anaconda3
+	module load anaconda
 
 	# Create your env
 	conda create -n env-name python=3.6 jupyter

--- a/aalto/welcomestudents.rst
+++ b/aalto/welcomestudents.rst
@@ -85,7 +85,7 @@ For GPU computing, the :doc:`Paniikki Linux computer lab
 <../aalto/paniikki>` (`map
 <https://usefulaaltomap.fi/#!/select/paniikki>`_) has GPUs in all
 workstations.  Software is available via ``module spider $name`` to
-search and ``module load $name`` to load (and the module ``anaconda3``
+search and ``module load $name`` to load (and the module ``anaconda``
 has Python, tensorflow, etc.).  Read the :doc:`Paniikki cheatsheet
 here <../aalto/paniikki>`.  The instructions for :doc:`Aalto
 workstations <../aalto/linux>` sort of apply there as well.  The
@@ -141,7 +141,7 @@ found for your own use via the Aalto software portals.
 
 The Lmod (``module``) system provides more software on
 ``brute``/``force`` and in Paniikki.  For example, to access a bunch
-of scientific Python software, you can do ``module load anaconda3``.
+of scientific Python software, you can do ``module load anaconda``.
 The :doc:`researcher-focused instructions are here
 </triton/tut/modules>`, but like many things on this site you may have
 to adapt to the student systems.
@@ -151,7 +151,7 @@ Common software:
 .. csv-table::
    :delim: |
 
-   Python | ``module load anaconda3`` on Linux
+   Python | ``module load anaconda`` on Linux
    Tensorflow etc packages | same as Python, in Paniikki
 
 

--- a/triton/apps/jupyter.rst
+++ b/triton/apps/jupyter.rst
@@ -208,7 +208,7 @@ Software and kernels
 We have various kernels automatically installed (these instructions
 should apply to both JupyterHub and ``sjupyter``):
 
-* Python (2 and 3 via ``anacondaN/latest`` modules + a few
+* Python (2 and 3 via some recent anaconda modules + a few
   more Python modules.)
 * Matlab (latest module)
 * Bash kernel
@@ -382,12 +382,3 @@ config and setup is hackish.
     pip install matlab_kernel
     cd $MATLABROOT/extern/engines/python/
     python setup.py
-
-  R support:
-    https://irkernel.github.io/installation/
-    ``module load anaconda3 R/3.4.1-iomkl-triton-2017a``.
-
-
-  Bash:
-    ml load anaconda3
-    python -m bash_kernel.install

--- a/triton/apps/keras.rst
+++ b/triton/apps/keras.rst
@@ -2,7 +2,7 @@ Keras
 =====
 
 :supportlevel:
-:pagelastupdated: 2018
+:pagelastupdated: 2020-02-20
 :maintainer:
 
 Keras is a neural network library which runs on tensorflow (among
@@ -11,10 +11,8 @@ other things).
 Basic usage
 -----------
 
-Keras is available in the ``anaconda`` module (GPU version) and
-some other anaconda modules.  Run ``module spider anaconda`` to list
-available modules.  The ``tf2`` (tensorflow 2) versions work on both
-CPU and GPU.
+Keras is available in the ``anaconda`` module and some other anaconda
+modules.  Run ``module spider anaconda`` to list available modules.
 
 You probably want to learn how to run in the :doc:`GPU queues
 <../tut/gpu>`.  The other information in the :doc:`tensorflow

--- a/triton/apps/keras.rst
+++ b/triton/apps/keras.rst
@@ -11,14 +11,15 @@ other things).
 Basic usage
 -----------
 
-Keras is available in the ``anaconda2/3`` modules (GPU version) and
-some other anaconda modules.  Run ``module spider anaconda3`` to list
-available modules.  The ``-cpu`` modules have a tensorflow that will
-run on CPUs.  The others have GPU-only versions, so you *have* to run
-in the :doc:`GPU queues <../tut/gpu>`.  The other information in the
-:doc:`tensorflow <tensorflow>` page also applies, especially the
-``--constraint`` options to restrict to the GPUs that have new enough
-features.
+Keras is available in the ``anaconda`` module (GPU version) and
+some other anaconda modules.  Run ``module spider anaconda`` to list
+available modules.  The ``tf2`` (tensorflow 2) versions work on both
+CPU and GPU.
+
+You probably want to learn how to run in the :doc:`GPU queues
+<../tut/gpu>`.  The other information in the :doc:`tensorflow
+<tensorflow>` page also applies, especially the ``--constraint``
+options to restrict to the GPUs that have new enough features.
 
 Example
 -------
@@ -26,7 +27,7 @@ Example
 ::
 
    srun -p gpu --pty bash
-   module load anaconda3
+   module load anaconda
    python3
    >>> import keras
    Using TensorFlow backend.

--- a/triton/apps/python.rst
+++ b/triton/apps/python.rst
@@ -75,15 +75,23 @@ tries to install globally for all users. Instead, you should do this
 This is quick and effective best used for leaf packages without many
 dependencies and if you don't switch Python modules often.
 
-**Warning!** If you do this, then the module will be shared among all
-your projects. It is quite likely that eventually, you will get some
-incompatibilities between the Python you are using and the modules
-installed. In that case, you are on your own (simple recommendation is
-to remove all modules from ``~/.local/lib/pythonN.N`` and reinstall). **If
-you get incompatible module errors, our first recommendation will be to
-remove everything installed this way and use conda/virtual
-environments instead.**  It's not a bad idea to do this when you
-switch to environments anyway.
+.. warning:: ``pip install --user`` can result in incompatibilities
+
+   If you do this, then the module will be shared among all
+   your projects. It is quite likely that eventually, you will get some
+   incompatibilities between the Python you are using and the modules
+   installed. In that case, you are on your own (simple recommendation is
+   to remove all modules from ``~/.local/lib/pythonN.N`` and reinstall). **If
+   you get incompatible module errors, our first recommendation will be to
+   remove everything installed this way and use conda/virtual
+   environments instead.**  It's not a bad idea to do this when you
+   switch to environments anyway.
+
+   If you encounter problems, remove all your user packages::
+
+      rm -r ~/.local/lib/python*.*/
+
+   and reinstall everything *after* loading the environment you want.
 
 .. note:: Example of dangers of ``pip install --user``
 
@@ -107,7 +115,8 @@ Anaconda and conda environments
 Continuum Analytics (open source, of course). It is nothing fancy, they just take a lot of
 useful scientific packages and put them all together, make sure they
 work, and do some sort of optimization. They also include most of the
-most common computing and data science packages. It is also all open
+most common computing and data science packages and non-Python
+compiled software and libraries. It is also all open
 source, and is packaged nicely so that it can easily be installed on
 any major OS.
 

--- a/triton/apps/python.rst
+++ b/triton/apps/python.rst
@@ -45,7 +45,7 @@ Triton supports all of these.
 Quickstart
 ----------
 
-Use ``module load anaconda3`` (or ``module load anaconda2``) to get a
+Use ``module load anaconda`` (or ``module load anaconda2`` for Python 2) to get a
 modern Python.
 
 If you have simple needs, use :ref:`pip install --user
@@ -103,7 +103,7 @@ versions):
 
 ::
 
-    module load anaconda3    # python3
+    module load anaconda     # python3
     module load anaconda2    # python2
 
 Conda environments
@@ -128,7 +128,7 @@ thus messing up quota accounting. This prevents that.
    load same version each time you source the environment::
 
        # Load anaconda first.  This must always be done before activating the env!
-       module load anaconda3     # or anaconda3
+       module load anaconda
 
 -  Create an environment::
 

--- a/triton/apps/python.rst
+++ b/triton/apps/python.rst
@@ -13,12 +13,17 @@ Python distributions
 |                          | Python to use            | How to install own       |
 |                          |                          | packages                 |
 +==========================+==========================+==========================+
-| Most of the use cases,   | Anaconda 2/3             | conda environment +      |
+| I don't really care,     | Anaconda                 |                          |
+| I just want recent stuff | ``module load anaconda`` |                          |
+| and to not worry.        |                          |                          |
+|                          |                          |                          |
++--------------------------+--------------------------+--------------------------+
+| Most of the use cases,   | Anaconda                 | conda environment +      |
 | but sometimes different  |                          | conda                    |
 | versions of modules      |                          |                          |
 | needed                   |                          |                          |
 +--------------------------+--------------------------+--------------------------+
-| Simple programs with     | Anaconda 2/3             | ``pip install --user``   |
+| Simple programs with     | Anaconda                 | ``pip install --user``   |
 | common packages, not     |                          |                          |
 | switching between        |                          |                          |
 | Pythons often            |                          |                          |
@@ -80,6 +85,14 @@ remove everything installed this way and use conda/virtual
 environments instead.**  It's not a bad idea to do this when you
 switch to environments anyway.
 
+.. note:: Example of dangers of ``pip install --user``
+
+   Someone did ``pip install --user tensorflow``.  Some time later,
+   they noticed that they couldn't use Tensorflow + GPUs.  We couldn't
+   reproduce the problem, but in the end found they had this local
+   install that was hiding any Tensorflow in any module (forcing a CPU
+   version on them).
+
 Note: ``pip`` installs from the `Python Package Index
 <https://pypi.python.org/pypi>`__.
 
@@ -91,7 +104,7 @@ Anaconda and conda environments
 -------------------------------
 
 `Anaconda <https://www.continuum.io>`__ is a Python distribution by
-Continuum Analytics. It is nothing fancy, they just take a lot of
+Continuum Analytics (open source, of course). It is nothing fancy, they just take a lot of
 useful scientific packages and put them all together, make sure they
 work, and do some sort of optimization. They also include most of the
 most common computing and data science packages. It is also all open
@@ -105,6 +118,14 @@ versions):
 
     module load anaconda     # python3
     module load anaconda2    # python2
+
+.. note::
+
+   Before 2020, Python3 was via the ``anaconda3`` module (note the
+   ``3`` on the end).  That's still there, but in 2020 we completely
+   revised our Anaconda installation system, and dropped active
+   maintenance of Python 2.  All updates are in ``anaconda`` only in
+   the future.
 
 Conda environments
 ~~~~~~~~~~~~~~~~~~

--- a/triton/apps/python.rst
+++ b/triton/apps/python.rst
@@ -9,34 +9,36 @@ system provided packages are ofter not complete or getting old.
 Python distributions
 --------------------
 
-+--------------------------+--------------------------+--------------------------+
-|                          | Python to use            | How to install own       |
-|                          |                          | packages                 |
-+==========================+==========================+==========================+
-| I don't really care,     | Anaconda                 |                          |
-| I just want recent stuff | ``module load anaconda`` |                          |
-| and to not worry.        |                          |                          |
-|                          |                          |                          |
-+--------------------------+--------------------------+--------------------------+
-| Most of the use cases,   | Anaconda                 | conda environment +      |
-| but sometimes different  |                          | conda                    |
-| versions of modules      |                          |                          |
-| needed                   |                          |                          |
-+--------------------------+--------------------------+--------------------------+
-| Simple programs with     | Anaconda                 | ``pip install --user``   |
-| common packages, not     |                          |                          |
-| switching between        |                          |                          |
-| Pythons often            |                          |                          |
-+--------------------------+--------------------------+--------------------------+
-| Special advanced cases.  | Python from module       | virtualenv + pip install |
-|                          | system                   |                          |
-+--------------------------+--------------------------+--------------------------+
++----------------------+-------------------------------+------------------------+
+|                      | Python to use                 | How to install own     |
+|                      |                               | packages               |
++======================+===============================+========================+
+| I don't really care, | Anaconda                      |                        |
+| I just want recent   | ``module load anaconda``      |                        |
+| stuff and to not     |                               |                        |
+| worry.               |                               |                        |
++----------------------+-------------------------------+------------------------+
+| Simple programs with | Anaconda                      | ``pip install --user`` |
+| common packages, not | ``module load anaconda``      |                        |
+| switching between    |                               |                        |
+| Pythons often        |                               |                        |
++----------------------+-------------------------------+------------------------+
+| Your own conda       | Miniconda                     | conda environment +    |
+| environment          | ``module load miniconda``     | conda                  |
+|                      |                               |                        |
+|                      |                               |                        |
++----------------------+-------------------------------+------------------------+
+| Your own virtual     | Module virtualenv             | virtualenv + pip +     |
+| environment          | ``module load py-virtualenv`` | setuptools             |
+|                      |                               |                        |
+|                      |                               |                        |
++----------------------+-------------------------------+------------------------+
 
-There are two main versions of Python: 2 and 3. There are also different
-distributions: The "regular" CPython, Anaconda (a package containing
-CPython + a lot of other scientific software all bundled togeter), PyPy
-(a just-in-time compiler, which can be much faster for some use cases).
-Triton supports all of these.
+The main version of modern Python is 3. Support for old Python 2 ended at the
+end of 2019. There are also different distributions: The "regular" CPython,
+Anaconda (a package containing CPython + a lot of other scientific software all
+bundled togeter), PyPy (a just-in-time compiler,  which can be much faster for
+some use cases). Triton supports all of these.
 
 -  For general scientific/data science use, we suggest that you use
    Anaconda. It comes with the most common scientific software included,
@@ -44,8 +46,6 @@ Triton supports all of these.
 -  There are many other "regular" CPython versions in the module system.
    These are compiled and optimized for Triton, and are highly
    recommended.  The default system Python is old and won't be updated.
--  PyPy is still mainly for advanced use (it can be faster under certain
-   cases, but does not work everywhere). It is available in a module.
 
 Quickstart
 ----------
@@ -57,8 +57,6 @@ If you have simple needs, use :ref:`pip install --user
 <pip-install-user>` to install packages.  For complex needs, use
 :ref:`anaconda + conda environments <conda>` to isolate your
 projects.
-
-
 
 .. _pip-install-user:
 
@@ -104,19 +102,17 @@ dependencies and if you don't switch Python modules often.
 Note: ``pip`` installs from the `Python Package Index
 <https://pypi.python.org/pypi>`__.
 
-
-
 .. _conda:
 
 Anaconda and conda environments
 -------------------------------
 
 `Anaconda <https://www.continuum.io>`__ is a Python distribution by
-Continuum Analytics (open source, of course). It is nothing fancy, they just take a lot of
-useful scientific packages and put them all together, make sure they
-work, and do some sort of optimization. They also include most of the
-most common computing and data science packages and non-Python
-compiled software and libraries. It is also all open
+Continuum Analytics (open source, of course). It is nothing fancy,
+they just take a lot of useful scientific packages and their dependencies
+and put them all together, make sure they work, and do some optimization.
+They also include most of the most common computing and data science packages
+and non-Python compiled software and libraries. It is also all open
 source, and is packaged nicely so that it can easily be installed on
 any major OS.
 
@@ -139,63 +135,54 @@ versions):
 Conda environments
 ~~~~~~~~~~~~~~~~~~
 
+If you encounter a situation where you need to create your own environment,
+we recommend that you use conda environments. When you create your own
+environment the packages from the base environment (default environment
+installed by us) will not be used, but you can choose which packages you want
+to install.
+
+We nowadays recommend that you use the ``miniconda``-module for installing these
+environments. Miniconda is basically a minimal Anaconda installation that can be used to
+create your own environments.
+
+Do note that these environments can be quite big and if you have multiple
+environments installed you can run into quota issues in your ``/home``. If
+you encounter such issues do contact us. In the past we recommended installing
+conda environments under ``$WRKDIR``, but this can cause file system problems
+when launching array jobs and is thus no longer recommended.
+
 **virtualenv** does not work with Anaconda, use ``conda`` instead.
 
-A conda environment lets you install all your own packages. Your home
-directories are very small, so it requires some initial steps. You see
-``module load teflon`` here a lot: conda does bad things with permissions,
-thus messing up quota accounting. This prevents that.
-
--  Initial setup: link the conda cache to your work directory (an
-   rsync error because ``~/.conda`` doesn't exist is OK)::
-
-       # Move your package cache to your work directory.  The following does it automatically.
-       rsync -lrt ~/.conda/ $WRKDIR/conda/ && rm -r ~/.conda
-       ln -sT $WRKDIR/conda ~/.conda
-       quotafix -gs --fix $WRKDIR/conda
-
--  Load the anaconda version you want to use. You will need to always
+-  Load the miniconda module. You should look up the version and use
    load same version each time you source the environment::
 
-       # Load anaconda first.  This must always be done before activating the env!
-       module load anaconda
+       # Load miniconda first.  This must always be done before activating the env!
+       module load miniconda
 
--  Create an environment::
+-  Create an environment. This needs to be done once::
 
-       # create environment with package pip in it
-       module load teflon
-       conda create --prefix PATH/TO/DIR python pip ipython ...
-       module unload teflon
+       # create environment with the packages you require
+       conda create -n ENV_NAME python pip ipython tensorflow-gpu pandas ...
+
+-  Activate the environment. This needs to be done every time you load
+   the environment::
+
+       # This must be run in each shell to set up the environment variables properly.
+       # make sure module is loaded first.
+       source activate ENV_NAME
 
 -  Activating and using the environment, installing more packages,
    etc. can be done either using ``conda install`` or ``pip install``::
 
-       # This must be run in each shell to set up the environment variables properly.
-       # make sure module is loaded first.
-       source activate PATH/TO/DIR
-
        # Install more packages, either conda or pip
-       module load teflon
        conda search PACKAGE_NAME
        conda install PACKAGE_NAME
        pip install PACKAGE_NAME
-       module unload teflon
 
 -  Leaving the environment when done (optional)::
 
        # Deactivate the environment
        source deactivate
-
--  If you run into "quota exceeded" problems, you need to do the first
-   steps above which move the .conda directory to another folder. The
-   quotafix command may be useful to try to reset things (see above),
-   but if that doesn't work: in the worst case, remove everything and
-   recreate it.::
-
-       # remove all conda things
-       rm -r ~/.conda $WRKDIR/conda
-       # Remove anything installed with pip install --user.
-       rm -r ~/.local/lib/python*.*/
 
 -  Worst case, you have incompatibility problems. Remove everything,
    including the stuff installed with ``pip install --user``. If you've
@@ -216,15 +203,6 @@ A few notes about conda environments:
 -  Often the same goes for other python based modules. We have setup
    many modules that do use anaconda as a backend. So, if you know what
    you are doing this might work.
--  The commands below will fail:
-
-   -  ``conda create -n foo pip`` # tries to use the global dir, use the
-      ``--prefix`` instead
-
-   -  ``conda create --prefix $WRKDIR/foo --clone root`` # will fail as our
-      anaconda module has additional packages (e.g. via pip) installed.
-
-
 
 .. _virtualenv:
 
@@ -238,6 +216,9 @@ works on other systems easily so it's good to know about.
 
 ::
 
+    # Load module python
+    module load py-virtualenv
+
     # Create environment
     virtualenv DIR
 
@@ -249,30 +230,6 @@ works on other systems easily so it's good to know about.
 
     # deactivate the virtualenv
     deactivate
-
-
-
-Python optimized for Triton
----------------------------
-
-There are Python modules installed with the typical software setup
-against :doc:`EasyBuild toolchains <../apps/index>`. While some of the
-more general packages available with anaconda installation might be
-missing, the Numpy and Scipy installations on these modules are highly
-optimized against the installed linear algebra libraries. A typical
-module loading using these toolchains could be
-
-::
-
-    module load Python/2.7.11-goolf-triton-2016a
-    module load numpy/1.11.1-goolf-triton-2016a-Python-2.7.11
-    module load scipy/0.18.0-goolf-triton-2016a-Python-2.7.11
-
-Use ``module spider Python`` to see available modules. More specialized
-modules like Tensorflow, Theano etc. will be installed against these
-modules so that they can be in optimal settings. Submit your issue in
-tracker if you wish some other Python modules to be included in these
-installations.
 
 .. _python-ipyparallel:
 
@@ -309,8 +266,6 @@ most advanced way to use ipyparallel, but works for interactive use.
 
 See also: :doc:`../examples/python/ipyparallel/ipyparallel` for a version
 which goes in a slurm script.
-
-
 
 Background: ``pip`` vs ``python`` vs ``anaconda`` vs ``conda`` vs ``virtualenv``
 --------------------------------------------------------------------------------
@@ -359,8 +314,6 @@ On Triton we have added some packages on top of the Anaconda
 installation, so cloning the entire Anaconda environment to local conda
 environment will not work (not a good idea in the first place but some
 users try this every now and then).
-
-
 
 Examples
 --------

--- a/triton/apps/tensorflow.rst
+++ b/triton/apps/tensorflow.rst
@@ -14,24 +14,27 @@ Basic usage
 
 First, check the tutorials up to and including :doc:`../tut/gpu`.
 
-With tensorflow, you have to decide at *install time* if you want a
-version that runs on CPUs or GPUs.  This means that we can't install
-it for everyone and expect it to work everywhere - you have to load
-something different if you want it to run on login node/regular nodes
-(probably for testing) or GPU nodes.  You probably want to use GPUs.
+The basic way to use is via the Python in the ``anaconda`` module.
+The versions with ``-tf2`` (the default ones) have Tensorflow 2
+installed, so it works on both the CPU and GPU queues.  If you use
+``module spider anaconda``, you can see a ``-tf1`` version available.
 
-The basic way to use is via the Python in the ``anaconda3`` module (or
-``anaconda2``) - but these modules have the GPU version installed, so
-you can't run or test on the login node.
+.. warning:: Tensorflow 1.x was CPU-only or GPU-only
 
-If you ``module spider anaconda3`` (or 2), you can see several
-versions ending in ``-cpu`` or ``-gpu``.  These have respectively the
-CPU and GPU versions of tensorflow installed.  Don't load any
-additional CUDA modules, anaconda includes everything.
+   With tensorflow 1.x, you have to decide at *install time* if you want a
+   version that runs on CPUs or GPUs.  This means that we can't install
+   it for everyone and expect it to work everywhere - you have to load
+   something different if you want it to run on login node/regular nodes
+   (probably for testing) or GPU nodes.  The old ``-cpu`` and ``-gpu``
+   versions in the ``anaconda2`` and ``anaconda3`` modules denoted this.
+
+   With tensorflow 2.x, they solved this problem (thankfully)
+
+Don't load any additional CUDA modules, anaconda includes everything.
 
 If you use GPUs, you need ``--constraint='kepler|pascal|volta'`` in
 order to select a GPU new enough to run tensorflow.  (Note that as we
-get never cards, this will need further updating).
+get newer cards, this will need further updating).
 
 .. include:: ../examples/tensorflow/tensorflow_mnist.rst
 

--- a/triton/apps/tensorflow.rst
+++ b/triton/apps/tensorflow.rst
@@ -50,5 +50,5 @@ Common problems
   for this is to use the newer `anaconda`-modules.
 
 * Random CUDA errors: don't load any other CUDA modules, only
-  `anaconda`.  Anaconda includes the necessary libraries in compatible
+  ``anaconda``.  Anaconda includes the necessary libraries in compatible
   versions.

--- a/triton/apps/tensorflow.rst
+++ b/triton/apps/tensorflow.rst
@@ -2,7 +2,7 @@ Tensorflow
 ==========
 
 :supportlevel: A
-:pagelastupdated: 2019-06-03
+:pagelastupdated: 2020-02-20
 :maintainer:
 
 .. highlight:: bash
@@ -16,19 +16,20 @@ First, check the tutorials up to and including :doc:`../tut/gpu`.
 
 The basic way to use is via the Python in the ``anaconda`` module.
 The versions with ``-tf2`` (the default ones) have Tensorflow 2
-installed, so it works on both the CPU and GPU queues.  If you use
-``module spider anaconda``, you can see a ``-tf1`` version available.
+installed.  If you use ``module spider anaconda``, you can see a
+``-tf1`` version available.
 
-.. warning:: Tensorflow 1.x was CPU-only or GPU-only
+.. warning:: Older versions of Tensorflow were CPU-only or GPU-only
 
-   With tensorflow 1.x, you have to decide at *install time* if you want a
-   version that runs on CPUs or GPUs.  This means that we can't install
-   it for everyone and expect it to work everywhere - you have to load
-   something different if you want it to run on login node/regular nodes
-   (probably for testing) or GPU nodes.  The old ``-cpu`` and ``-gpu``
-   versions in the ``anaconda2`` and ``anaconda3`` modules denoted this.
+   With older versions of tensorflow (<1.15.0), you have to decide at
+   *install time* if you want a version that runs on CPUs or GPUs. This
+   means that we can't install it for everyone and expect it to work
+   everywhere - you have to load something different if you want it to
+   run on login node/regular nodes (probably for testing) or GPU nodes.
+   The old ``-cpu`` and ``-gpu`` versions in the ``anaconda2``- and
+   ``anaconda3``-modules denoted this.
 
-   With tensorflow 2.x, they solved this problem (thankfully)
+   From tensorflow versions >= 1.15.0, they solved this problem (thankfully)
 
 Don't load any additional CUDA modules, anaconda includes everything.
 
@@ -43,12 +44,11 @@ Common problems
 ---------------
 
 * **ImportError: libcuda.so.1: cannot open shared object file: No such
-  file or directory**.  GPU tensorflow can only be imported on GPU
-  nodes (even though you'd think that you can import it and just not
-  use the GPUs).  So you can only run this code in the GPU queue.  You
-  could try something where you use CPU tensorflow for testing on
-  login and GPU tensorflow for running in batch.
+  file or directory**. Older versions of GPU tensorflow can only be imported
+  on GPU nodes (even though you'd think that you can import it and just not
+  use the GPUs).  So you can only run this code in the GPU queue. Solution
+  for this is to use the newer `anaconda`-modules.
 
 * Random CUDA errors: don't load any other CUDA modules, only
-  anaconda.  Anaconda includes the necessary libraries in compatible
+  `anaconda`.  Anaconda includes the necessary libraries in compatible
   versions.

--- a/triton/examples/cntk/cntk_mnist.rst
+++ b/triton/examples/cntk/cntk_mnist.rst
@@ -12,7 +12,7 @@ The full code for the example is in
 One can run this example with ``srun``::
 
   wget https://raw.githubusercontent.com/AaltoScienceIT/scicomp-docs/master/triton/examples/cntk/cntk_mnist.py
-  module load anaconda3/latest
+  module load anaconda
   srun -t 00:15:00 --gres=gpu:1 python cntk_mnist.py
 
 or with ``sbatch`` by submitting

--- a/triton/examples/python/ipyparallel/ipyparallel.slrm
+++ b/triton/examples/python/ipyparallel/ipyparallel.slrm
@@ -1,7 +1,7 @@
 #!/bin/bash
 #SBATCH -N 4
 
-module load anaconda3
+module load anaconda
 set -x
 
 ipcontroller --ip="*" &

--- a/triton/examples/python_openmp.rst
+++ b/triton/examples/python_openmp.rst
@@ -12,9 +12,9 @@ Python OpenMP example
     #SBATCH --cpus-per-task=4
     #SBATCH --mem-per-cpu=2G
     #SBATCH -o parallel_Python.out
-    
-    module load anaconda3 
-     
+
+    module load anaconda
+
     export OMP_NUM_THREADS=$SLURM_CPUS_PER_TASK
     srun -c $SLURM_CPUS_PER_TASK python parallel_Python.py
 

--- a/triton/examples/pytorch/pytorch_mnist.rst
+++ b/triton/examples/pytorch/pytorch_mnist.rst
@@ -12,7 +12,7 @@ The full code for the example is in
 One can run this example with ``srun``::
 
   wget https://raw.githubusercontent.com/AaltoScienceIT/scicomp-docs/master/triton/examples/pytorch/pytorch_mnist.py
-  module load anaconda3/latest
+  module load anaconda
   srun -t 00:15:00 --gres=gpu:1 python pytorch_mnist.py
 
 or with ``sbatch`` by submitting

--- a/triton/examples/pytorch/pytorch_mnist.sh
+++ b/triton/examples/pytorch/pytorch_mnist.sh
@@ -2,6 +2,6 @@
 #SBATCH --gres=gpu:1
 #SBATCH --time=00:15:00
 
-module load anaconda3/latest
+module load anaconda
 
 python pytorch_mnist.py

--- a/triton/examples/tensorflow/tensorflow_mnist.rst
+++ b/triton/examples/tensorflow/tensorflow_mnist.rst
@@ -12,7 +12,7 @@ The full code for the example is in
 One can run this example with ``srun``::
 
   wget https://raw.githubusercontent.com/AaltoScienceIT/scicomp-docs/master/triton/examples/tensorflow/tensorflow_mnist.py
-  module load anaconda3/latest
+  module load anaconda
   srun -t 00:15:00 --gres=gpu:1 python tensorflow_mnist.py
 
 or with ``sbatch`` by submitting

--- a/triton/examples/tensorflow/tensorflow_mnist.sh
+++ b/triton/examples/tensorflow/tensorflow_mnist.sh
@@ -2,6 +2,6 @@
 #SBATCH --gres=gpu:1
 #SBATCH --time=00:15:00
 
-module load anaconda3/latest
+module load anaconda
 
 python tensorflow_mnist.py

--- a/triton/tut/applications.rst
+++ b/triton/tut/applications.rst
@@ -43,7 +43,7 @@ Common applications
 
 For reference, here are the most common applications:
 
-* **Python:** ``module load anaconda3`` for the Anaconda distribution
+* **Python:** ``module load anaconda`` for the Anaconda distribution
   of Python 3, including a lot of useful packages.  :doc:`More info
   <../apps/python>`.
 

--- a/triton/tut/gpu.rst
+++ b/triton/tut/gpu.rst
@@ -60,8 +60,9 @@ Ready software
 
 We support these machine learning packages out of the box:
 
-* :doc:`Tensorflow <../apps/tensorflow>`: ``anaconda2`` /
-  ``anaconda3`` modules.  Use ``--constraint='kepler|pascal|volta'``
+* :doc:`Tensorflow <../apps/tensorflow>`:
+  ``anaconda`` module.  Use ``--constraint='kepler|pascal|volta'``.
+  See the Tensorflow page for info on older versions.
 * Keras: same module as tensorflow
 * PyTorch: same module as tensorflow
 * :doc:`Detectron <../apps/detectron>`: via :doc:`singularity images <../usage/singularity>`

--- a/triton/tut/modules.rst
+++ b/triton/tut/modules.rst
@@ -27,14 +27,14 @@ let's see what our Python is::
   $ python3 -V
   Python 3.4.9
 
-Now let's load the anaconda3 module, a more up to date Python with a
+Now let's load the ``anaconda`` module, a more up to date Python with a
 lot of libraries already included::
 
-  $ module load anaconda3
+  $ module load anaconda
   $ which python3
-  /share/apps2/anaconda/anaconda3/latest/bin/python3
+  /share/apps/anaconda-ci/fgci-centos7-generic/software/anaconda/2020-01-tf2/0251cd77/bin/python3
   $ python3 -V
-  Python 3.6.8 :: Anaconda custom (64-bit)
+  Python 3.7.6
 
 As you see, we have a newer Python.  Let's go back to blank::
 

--- a/triton/tut/serial.rst
+++ b/triton/tut/serial.rst
@@ -84,7 +84,7 @@ In general, anything you can do from the shell, you can do here::
     #SBATCH --time=0-00:05:00    # 5 mins
     #SBATCH --mem-per-cpu=500    # 500MB of memory
 
-    module load anaconda3
+    module load anaconda
     python -V
 
 **Exercise**: Try the Python version-printing script above.  Try


### PR DESCRIPTION
- Some initial changes done

- [x] The triton/apps/python.rst page still needs revisions, once we
  figure stuff out.

- [ ] Non-anaconda needs revising

- [x] remove mentions of moving the envs to scratch

- [ ] use miniconda + https://github.com/AaltoScienceIT/lmod-conda for
  making own environments

- Anyone else can work on this, and it doesn't have to be perfect
  before merging.