### PR TITLE
triton/a/sjupyter: note that sjupyter is available as a module

### DIFF
--- a/triton/apps/sjupyter.rst
+++ b/triton/apps/sjupyter.rst
@@ -3,12 +3,14 @@ Your own notebooks via ``sjupyter``
 
 .. note::
 
-   Now that Jupyterhub exists, this method of running Jupyter is not
+   Now that :doc:`Triton Jupyterhub <jupyter>` exists, this method of
+   running Jupyter is not
    so important.  It is only needed if you need more resources than
    JupyterHub can provide.
 
 We provide a command ``sjupyter`` which automates launching your own
-notebooks in the Slurm queue.  This gives you more flexibility in
+notebooks in the Slurm queue.  To use this, ``module load sjupyter``.
+This gives you more flexibility in
 choosing your nodes and resources than Jupyterhub, but also will after
 your and your department's Triton priority more because you are
 blocking others from using these resources.
@@ -59,6 +61,10 @@ Starting sjupyter
 
 We have the custom-built command ``sjupyter`` for
 starting Jupyter on Triton.
+
+First, you must load the ``sjupyter`` module::
+
+  module load sjupyter
 
 To run in the Triton queue (using more resources), just use
 ``sjupyter``.  This will start a notebook on the interactive Slurm


### PR DESCRIPTION
- With diskless nodes, there isn't a good way to install local things
  to /usr/local/bin (there probably is, but I don't know it).  So, I
  made sjupyter available as a module.  It would be better if this was
  in some default paths, but oh well.
- This has to be not just in path, but in the same path on all nodes.
  I had done some stuff with linking to put it in /usr/local/bin
  linked to NFS software, but that no longer works on diskless nodes.
- I could continue to manually install this on the login nodes, but
  this doesn't scale and isn't managed...