### PR TITLE
aalto/jh-instructors/: document self-service for adding TAs

### DIFF
--- a/aalto/jupyterhub-instructors/faq-hints.rst
+++ b/aalto/jupyterhub-instructors/faq-hints.rst
@@ -17,7 +17,9 @@ Instructions/hints
 
 - To add more instructors/TAs, go to `domesti.cs.aalto.fi
   <https://domesti.cs.aalto.fi>`_ and you can do it yourself.  You
-  must be connected to an Aalto network.
+  must be connected to an Aalto network.  See the `Aalto VPN guide
+  <https://www.aalto.fi/en/services/establishing-a-remote-connection-vpn-to-an-aalto-network>`_
+  for help with connecting to an Aalto network from outside.
 
 - Store your course data in a git repository (or some other version
   control system) and push it to :doc:`version.aalto.fi </aalto/git>`

--- a/aalto/jupyterhub-instructors/faq-hints.rst
+++ b/aalto/jupyterhub-instructors/faq-hints.rst
@@ -15,6 +15,10 @@ Instructions/hints
   answering questions about what to do with the data in the long
   term.  There can be a deputy who can also grant access.
 
+- To add more instructors/TAs, go to `domesti.cs.aalto.fi
+  <https://domesti.cs.aalto.fi>`_ and you can do it yourself.  You
+  must be connected to an Aalto network.
+
 - Store your course data in a git repository (or some other version
   control system) and push it to :doc:`version.aalto.fi </aalto/git>`
   or some such system.  ``git`` and relevant tools are all installed

--- a/aalto/jupyterhub-instructors/request-course.rst
+++ b/aalto/jupyterhub-instructors/request-course.rst
@@ -58,7 +58,8 @@ Required metadata is:
    * * 5. Instructors
      * Who will have access to the instructor data?  Instructors will
        be added to a Aalto unix group named ``jupyter-$courseslug`` to
-       provide access control.  To request new instructors, contact
+       provide access control.  To request new instructors, you do
+       this yourself (:doc:`see the relevant FAQ <faq-hints>`).  Or, email
        CS-IT and ask that people be added/removed from your group
        ``jupyter-$courseslug``.
 


### PR DESCRIPTION
- This service seems stable enough that it can be generally
  recommended.  Thanks to Markus for seeing it through.