### PR TITLE
jupyter.cs: mention kinit for file access, link to data description more

### DIFF
--- a/aalto/jupyterhub-data.rst
+++ b/aalto/jupyterhub-data.rst
@@ -54,6 +54,10 @@ available**.  In a terminal, run ``/m/jhnas/u/makedir.sh`` and you
 will automatically get a link from ``~/jupyter`` in your home
 directory to your user data.
 
+**Permission denied?** Run ``kinit`` in the shell - this authenticates
+yourself to the Aalto server and is required for secure access.  If
+you log in with ssh keys, you may need to do this.
+
 Remote access via network drive
 -------------------------------
 

--- a/aalto/jupyterhub-instructors/course-data.rst
+++ b/aalto/jupyterhub-instructors/course-data.rst
@@ -3,6 +3,11 @@
 Course data
 ===========
 
+.. seealso::
+
+   One of the best features of jupyter.cs is powerful data access.
+   See :doc:`../jupyterhub-data`
+
 If your course uses data, request a ``coursedata`` or ``shareddata``
 directory as mentioned above.  You need to add the data there
 yourself, either through the Jupyter interface or SMB mounting of

--- a/aalto/jupyterhub-instructors/faq-hints.rst
+++ b/aalto/jupyterhub-instructors/faq-hints.rst
@@ -7,6 +7,9 @@ Instructions/hints
 - Request a course when you are sure you will use it.  You can use the
   general use containers for writing notebooks before that point.
 
+- Don't forget about the :doc:`flexible ways of accessing course data
+  <../coursedata>`.
+
 - The course directory is stored according to the :doc:`Science-IT
   data policy </aalto/datapolicy>`.  In short, all data is stored in group
   directories (for these purposes, the course is a group).  The

--- a/aalto/jupyterhub-instructors/system-environment.rst
+++ b/aalto/jupyterhub-instructors/system-environment.rst
@@ -51,10 +51,11 @@ Data
 
 Data is available from outside JupyterHub: it is hosted on an
 Aalto-wide server provided by Aalto.  Thus, you can access it on your
-laptops, on Aalto public shell servers, and more.
+laptops, on Aalto public shell servers, and more.  A fast summary is
+below, but see :doc:`../jupyterhub-data` for the main info.
 
 * From your own laptop: The SMB server ``jhnas.org.aalto.fi`` path
-  ``/vol/jupyter/{u,courses}``.
+  ``/vol/jupyter/{course,$username}``.
 
   * Linux: "Connect to server" from the file browser, URL
     ``smb://jhnas.org.aalto.fi/vol/jupyter``


### PR DESCRIPTION
- Mention that `kinit` may be needed to access files on shell servers.

- Link to the newly-revised coursedata page from more locations.