### PR TITLE
Add page timestamp at the bottom from git

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -5,6 +5,7 @@ RUN apt-get update && apt-get install -y \
     build-essential \
     python-sphinx-rtd-theme \
     && rm -rf /var/lib/apt/lists/*
+RUN pip install -r /docbuild/meta/requirements.txt
 
 RUN mkdir -p /docbuild
 

--- a/_templates/footer.html
+++ b/_templates/footer.html
@@ -1,0 +1,9 @@
+{%- extends "!footer.html" %}
+
+{% block extrafooter %}
+  {%- if gitstamp %}
+    <p style="margin-top: 12px">
+      <span class="lastupdated">This page last updated {{ gitstamp }}.</span>
+    </p>
+  {%- endif %}
+{% endblock %}

--- a/conf.py
+++ b/conf.py
@@ -33,6 +33,14 @@ extensions = [
     'sphinx.ext.ifconfig',
     'sphinx.ext.mathjax',
 ]
+# Add timestamps from git
+try:
+    # https://github.com/jdillard/sphinx-gitstamp
+    import sphinx_gitstamp
+    extensions.append('sphinx_gitstamp')
+    gitstamp_fmt = "%d %b %Y"
+except:
+    print("sphinx_gitstamp is not installed, won't use git timestamps.")
 
 # Add any paths that contain templates here, relative to this directory.
 templates_path = ['_templates']

--- a/meta/requirements.txt
+++ b/meta/requirements.txt
@@ -1,0 +1,1 @@
+sphinx_gitstamp


### PR DESCRIPTION
- Use extension sphinx_gitstamp to do this.  Basically everything
  works automatically, but we need to manually put it into the footer.
- This is written to not fail if the extension is not installed, to
  make this as easy to build as possible.
- Untested on readthedocs so far.