### PR TITLE
cosmol: various fixups

### DIFF
--- a/triton/apps/cosmol.rst
+++ b/triton/apps/cosmol.rst
@@ -11,23 +11,25 @@ Comsol in Triton is best run in Batch-mode. To check which versions of Comsol ar
           #!/bin/bash
 
           # Ask for e.g. 20 compute cores
+          #SBATCH --time=0-10:00
+          #SBATCH --mem-per-cpu=2G
           #SBATCH -N 1
           #SBATCH -c 20
 
-	  cd $WRKDIR/my_comsol_directory
-	  module load Java
+          cd $WRKDIR/my_comsol_directory
+          module load Java
           module load comsol
 
-	  # Details of your input and output files
-	  INPUTFILE=input_model.mph
-	  OUTPUTFILE=output_model.mph
+          # Details of your input and output files
+          INPUTFILE=input_model.mph
+          OUTPUTFILE=output_model.mph
 
           comsol batch -clustersimple -launcher slurm -inputfile $INPUTFILE -outputfile $OUTPUTFILE -tmpdir $TMPDIR
 
 
--  Comsol can run even bigger jobs over multiple computing nodes with "-clustersimple". For this, please refer to Comsol online manual or ask for further help.
+-  Comsol can run even bigger jobs over multiple computing nodes with ``-clustersimple``. For this, please refer to Comsol online manual or ask for further help.
 -  Comsol uses a lot of temp file storage, which by default goes to
-   $HOME. Fix a bit like the following::
+   ``$HOME``. Fix a bit like the following::
 
        $ rm -rf ~/.comsol/
        $ mkdir /scratch/work/$USER/comsol_revoveries/

--- a/triton/apps/cosmol.rst
+++ b/triton/apps/cosmol.rst
@@ -30,4 +30,4 @@ Comsol in Triton is best run in Batch-mode. To check which versions of Comsol ar
 
        $ rm -rf ~/.comsol/
        $ mkdir /scratch/work/$USER/comsol_revoveries/
-       $ ln -sT /scratch/work/$USER/comsol_revoveries/ ~/.comsol/
+       $ ln -sT /scratch/work/$USER/comsol_revoveries/ ~/.comsol

--- a/triton/apps/cosmol.rst
+++ b/triton/apps/cosmol.rst
@@ -5,13 +5,14 @@ Comsol in Triton is best run in Batch-mode. To check which versions of Comsol ar
 
           module spider comsol
 
--  To run Comsol in a single node use the "-np" instead of "-clustersimple"::
+-  To run Comsol in a single node use ``-clustersimple`` and
+   ``-launcher slurm``::
 
           #!/bin/bash
 
           # Ask for e.g. 20 compute cores
           #SBATCH -N 1
-          #SBATCH -n 20
+          #SBATCH -c 20
 
 	  cd $WRKDIR/my_comsol_directory
 	  module load Java
@@ -21,7 +22,7 @@ Comsol in Triton is best run in Batch-mode. To check which versions of Comsol ar
 	  INPUTFILE=input_model.mph
 	  OUTPUTFILE=output_model.mph
 
-	  comsol batch -np $SLURM_NTASKS -inputfile $INPUTFILE -outputfile $OUTPUTFILE -tmpdir $TMPDIR
+          comsol batch -clustersimple -launcher slurm -inputfile $INPUTFILE -outputfile $OUTPUTFILE -tmpdir $TMPDIR
 
 
 -  Comsol can run even bigger jobs over multiple computing nodes with "-clustersimple". For this, please refer to Comsol online manual or ask for further help.


### PR DESCRIPTION
triton/apps/cosmol.rst: minor fixups

   triton/apps/cosmol.rst: use -launcher slurm and -clustersimple

   - This is what people on our issue tracker use, e.g. #691.  With a
    user we tested and it seems to actually use the requested number of
    CPUs.
   - Using -c seems better than -n in this situation, we thought in our
    garage today.  It's what others do at least.

   triton/apps/cosmol.rst: fix linking the .cosmol dir

   - We need to not have trailing slash, or it expects it place it there
    (-T), not in that directory.