### PR TITLE
Updating the SSH page in docs

### DIFF
--- a/scicomp/ssh.rst
+++ b/scicomp/ssh.rst
@@ -41,71 +41,43 @@ You will not receive an authenticity prompt upon first login if the server's *pu
     ssh-keygen -f ~/.ssh/known_hosts -F kosh.aalto.fi
 
 
-Login without password: ssh keys
-================================
+SSH keys: better than just passwords
+====================================
 
-You may get tired of typing a password all the time: and you should,
-using a key is faster and more secure.  You make a *ssh key* on your
-own computer, copy the *public* key to the other server, and then can
-login without a password.
+By default, you will need to type your password each time you wish to ssh into Triton, which can be tiresome, particularly if you regularly have multiple sessions open simultaneously. A more secure (and faster) way to authenticate yourself is to use a *shh key pair* and encrypt the this with a strong password. `xkcd <https://www.xkcd.com/936/>`__ has good and amusing recommendations on the subject of passwords. This authentication method will allow you to log into multiple ssh sessions while only needing to enter your password once, saving you time and keystrokes.
 
-Note: this section is only for connecting *to* Triton.  Once you are
-connected the first time, a key for internal connections is
-automatically made.
+Generate an SSH key
+-------------------
 
-Linux
------
+While there are many options for the key generation program ``ssh-keygen``, here are the four main ones.
 
-We highly recommend you follow these steps on the first login to set up
-passwordless SSH.  This will make your life much more pleasant, and can
-be used when connecting to computers other than Triton. Using keys will
-save you the trouble of entering passwords every time, since ssh stores
-the key once and uses it for logging you in in the future.
+- *-t* -> the cryptosystem used to make the unique key-pair and encrypt it.
+- *-b* -> the number of key bits
+- *-f* -> filename of key
+- *-C* -> comment on what the key is for
 
-**First, create the keypair on your own computer.** **Do not copy
-private keys from other computers - one computer=one private key, and
-copy only the public key (.pub) to any computer you want to log in to.**
-Protect your SSH keyfiles with a *passphrase*. When asked to enter one,
-use 3+ words, mixing languages, CAsE, or inflection, but make it
-something you can remember without sticky notes.  `xkcd has some
-opinions on this. <https://www.xkcd.com/936/>`__  A key without a
-passphrase is like a password just sitting on disk - so be careful
-here.  Passwordless keys are OK in certain cases, such as internal
-triton connections.
-
+Here are our recommended input options for key generation.
 ::
+    ssh-keygen -t rsa -b 4096 -f ~/.ssh/id_rsa_triton -C "triton key for ${USER}"
 
-    ssh-keygen -o
+After running this command in the terminal, you will be prompted to enter a password. **PLEASE** use a strong unique password. Upon confirming the password, you will be presented with the key fingerprint as both a SHA256 hex string as well as randomart image. Your new key pair should be found in the hidden ``~/.ssh`` directory. If you wish to use keys for other servers, you should generate **new** key pairs and use **different** passwords.
 
-**Then, copy the key to computers you want to log into:** Use the
-``ssh-copy-id`` script to copy the public key file to Triton.  This will
-put the key in ``~/.ssh/authorized_keys`` (you can check this file to see
-everything that's there).   (To do this manually, put the contents of
-``.ssh/id_rsa.pub`` file into ``~/.ssh/authorized_keys`` on Triton.  If
-you do this yourself, you may set set the permissions on
-``.authorized_keys`` file: ``chmod u=rwx .ssh/``, ``chmod u=rw``
-``.ssh/authorized_keys``.)
+Copy public key to server
+-------------------------
 
-Finally, you should be able to login automatically.  A program called
-``ssh-agent`` (or ``gnome-keyring``) decrypts the key once and holds
-it and uses it each time you need to connect.  If it doesn't work
-automatically, try running ``ssh-add`` yourself once.
+In order to use your key-pair to login to Triton, you first need to securely copy the desired *public key* to the machine with ``ssh-copy-id``. The script will also add the key to the ``~/.ssh/authorized_keys`` file on the server. You will be prompted to enter your Aalto password to initiate the secure copy of the file to Triton.
+::
+    ssh-copy-id -i ~/.ssh/id_rsa_triton.pub login_name@triton.aalto.fi
 
-Mac
----
-You can follow same instructions from Linux.
 
-Windows
--------
-Realistically, on windows setting up keys takes some time.  You don't
-need to worry about it (you will still have an ssh key on triton that
-is used for internal connections).
+Login with SSH key
+-------------------
 
-You can make keys using ``puttygen``.  Here is `a tutorial`__.  You
-should make a new key for each computer you have.
+To avoid having to type the decryption password, the *private key* it needs to be added to the ``ssh-agent`` with the command
+::
+    ssh-add ~/.ssh/id_rsa_triton
 
-__ https://devops.ionos.com/tutorials/use-ssh-keys-with-putty-on-windows/
-
+Once the password is added, you can ssh into Triton as normal but will immediately be connected without any further prompts. If you are unsure whether a ``ssh-agent`` process is running on your machine, ``ps -C ssh-agent`` will tell you if there is. To start a new agent, use ``eval $(ssh-agent)``.
 
 
 Config file: don't type so many options

--- a/scicomp/ssh.rst
+++ b/scicomp/ssh.rst
@@ -124,27 +124,29 @@ There are optional ssh settings that may be useful for your work, such as
         IdentityFile ~/.ssh/id_rsa_triton
 
 
-
 ..
   The purpose of this document is to describe how to use ssh such that
   usage is reasonably convenient and secure. Key takeaways:
 
+  - Logging into server with ssh and verify the server authenticity
   - Creating ssh keys
-      - Do not copy private keys around. Instead create a separate
-        private/public key pair for each device, and copy the public
-        keys to those hosts you need to connect to.
-      - Always protect the private key by a passphrase.
-  - Use a ssh agent (ssh-agent, GNOME keyring, macOS keyring, putty
-    Pageant, etc.) in order to avoid having to type your key password
-    all the time.
-  - Prefer ProxyJump/ProxyCommand to agent forwarding.
-
-
+      - Generate complex key with strong password
+      - One key for each server
+  - Login with ssh key
+      - ssh-agent holds password for session
+      - save password
+  - Setting up an ssh-config file to save & map your preferred login settings
 
 
 References
 ==========
 
-- https://infosec.mozilla.org/guidelines/openssh
+- https://www.ssh.com/ssh/
 - https://blog.0xbadc0de.be/archives/300
-- https://nvlpubs.nist.gov/nistpubs/ir/2015/NIST.IR.7966.pdf
+- https://www.phcomp.co.uk/Tutorials/Unix-And-Linux/ssh-passwordless-login.html
+- https://en.wikibooks.org/wiki/OpenSSH/
+- https://linuxize.com/post/ssh-command-in-linux/#how-to-use-the-ssh-command
+- https://linuxize.com/post/how-to-setup-passwordless-ssh-login/
+- https://hpc-uit.readthedocs.io/en/latest/account/login.html
+- https://www.mn.uio.no/geo/english/services/it/help/using-linux/ssh-tips-and-tricks.html
+- https://infosec.mozilla.org/guidelines/openssh

--- a/scicomp/ssh.rst
+++ b/scicomp/ssh.rst
@@ -2,23 +2,43 @@
 SSH
 ===
 
-.. seealso::
+This walk-through presumes that the user
 
-   For triton specific instructions see :doc:`Connecting to triton
-   page </triton/tut/connecting>`.
+- is working on a Linux machine or Mac
+- has ``OpenSSH`` installed: ``ssh -V`` in the terminal to check
+- has an account on the server of interest
+- is connected to the Aalto network
 
-``ssh`` is a easy, secure way of connecting to remote computers.  The
-Internet is practically run on it.  This page tells you how to *make
-ssh work nicer*.
+We will be focusing on connecting to *Triton* but the methods described below are applicable to any of Aalto's other :doc:`remote servers </aalto/remoteaccess.html>`.
 
 
 Basic use: connect to a server
 ==============================
 
-``ssh username@host.fi`` is the basic method of use - ``username`` is
-the username, and ``host.fi`` is the server to which you connect, for
-example ``triton.aalto.fi``.  See :doc:`connecting to triton
-</triton/tut/connecting>`.
+The standard login command is ``ssh login_name@host_name``,  where ``login_name`` is your standard Aalto login and ``host_name`` is the address of the server you with to connect. In the case of Triton, the ``host_name`` is ``triton.aalto.fi``.
+
+First time login
+----------------
+
+For Triton, you will be prompted to affirm that you wish to *ssh* into this server for the first time.
+::
+    The authenticity of host 'triton.aalto.fi (130.233.229.116)' can't be established.
+    ECDSA key fingerprint is SHA256:04Wt813WFsYjZ7KiAyo3u6RiGBelq1R19oJd2GXIAho.
+    Are you sure you want to continue connecting (yes/no)?
+
+Compare the key fingerprint you get to the one for the machine at this **link**, and if they do not match, please contact SciComp IT **immediately**. If they do match, type ``yes`` and press enter. You will receive a notice
+::
+    Warning: Permanently added 'triton.aalto.fi,130.233.229.116' (ECDSA) to the list of known hosts.
+
+The *public key* that identifies Triton will be stored in ``~/.ssh/known_hosts`` and you ought not get this prompt again. You will be also asked to input your Aalto password before you are fully logged in.
+
+Known servers
+-------------
+
+You will not receive an authenticity prompt upon first login if the server's *public key* can be found in a list of known hosts. To check whether a server, *Kosh* for example, is known
+::
+    ssh-keygen -f /etc/ssh/ssh_known_hosts -F kosh.aalto.fi
+    ssh-keygen -f ~/.ssh/known_hosts -F kosh.aalto.fi
 
 
 Login without password: ssh keys

--- a/scicomp/ssh.rst
+++ b/scicomp/ssh.rst
@@ -83,25 +83,45 @@ Once the password is added, you can ssh into Triton as normal but will immediate
 Config file: don't type so many options
 =======================================
 
-Openssh on Linux and Mac can be made nicer if you set up a config file
-(``.ssh/config``)::
+Remembering the full settings list for the server you are working on each time you log in can be tedious. A ssh ``config`` file allows you to store your preferred settings and map them to much simpler login commands. To create a new user-restricted ``config`` file
+::
+    touch ~/.ssh/config && chmod 600 ~/.ssh/config
 
-    # Host alias triton: "ssh triton" instead of "ssh triton.aalto.fi".
-    # You can set more options here.
+
+For a new configuration, you need specify in ``config`` at minimum the
+
+- Host: the name of the settings list
+- User: your login name when connecting to the server
+- Hostname: the address of the server
+
+So for the simple Triton example, it would be
+::
+    # Configuration file for simplifying SSH logins
+    #
+    # HPC slurm cluster
     Host triton
-        User YOUR_USERNAME
+        User LOGIN_NAME
         Hostname triton.aalto.fi
-        # Only if not on Aalto networks:
-        # Next line *automatically* proxies you through kosh.aalto.fi.  You
-        # probably want to set up a "kosh" host if username is different, and
-        # set up public key authentication on kosh too.
-        ProxyCommand ssh kosh.aalto.fi -W %h:%p
-    # Defaults for all hosts.
-    Host *
-        # Following two lines allow SSH to reuse connections - second connections
-        # open very fast.  If problems (channels exceeded), disable it.
-        ControlMaster   auto
-        ControlPath     /tmp/.ssh-USERNAME-mux-%r@%h:%p
+
+and you would use ``ssh triton`` to log in. Any additional server configs can follow the first one and must start with declaring the configuration ``Host``.
+::
+    # general login server
+    Host kosh
+        User LOGIN_NAME
+        Hostname kosh.aalto.fi
+    # light-computing server
+    Host brute
+        User LOGIN_NAME
+        Hostname brute.aalto.fi
+
+There are optional ssh settings that may be useful for your work, such as
+::
+        # Turn on X11 forwarding for Xterm graphics access
+        ForwardX11 yes
+        # Connect through another server (eg Kosh) if not connected directly to Aalto network
+        ProxyCommand ssh kosh.aalto.fi -W %r@%h:%p
+        # Specify which ssh private key is used for login identification
+        IdentityFile ~/.ssh/id_rsa_triton
 
 
 

--- a/scicomp/ssh.rst
+++ b/scicomp/ssh.rst
@@ -9,7 +9,7 @@ This walk-through presumes that the user
 - has an account on the server of interest
 - is connected to the Aalto network
 
-We will be focusing on connecting to *Triton* but the methods described below are applicable to any of Aalto's other :doc:`remote servers </aalto/remoteaccess.html>`.
+We will be focusing on connecting to *Triton* but the methods described below are applicable to any of Aalto's other :doc:`remote servers </aalto/remoteaccess>`.
 
 
 Basic use: connect to a server
@@ -21,12 +21,14 @@ First time login
 ----------------
 
 For Triton, you will be prompted to affirm that you wish to *ssh* into this server for the first time.
+
 ::
     The authenticity of host 'triton.aalto.fi (130.233.229.116)' can't be established.
     ECDSA key fingerprint is SHA256:04Wt813WFsYjZ7KiAyo3u6RiGBelq1R19oJd2GXIAho.
     Are you sure you want to continue connecting (yes/no)?
 
 Compare the key fingerprint you get to the one for the machine at this **link**, and if they do not match, please contact SciComp IT **immediately**. If they do match, type ``yes`` and press enter. You will receive a notice
+
 ::
     Warning: Permanently added 'triton.aalto.fi,130.233.229.116' (ECDSA) to the list of known hosts.
 
@@ -36,6 +38,7 @@ Known servers
 -------------
 
 You will not receive an authenticity prompt upon first login if the server's *public key* can be found in a list of known hosts. To check whether a server, *Kosh* for example, is known
+
 ::
     ssh-keygen -f /etc/ssh/ssh_known_hosts -F kosh.aalto.fi
     ssh-keygen -f ~/.ssh/known_hosts -F kosh.aalto.fi
@@ -57,6 +60,7 @@ While there are many options for the key generation program ``ssh-keygen``, here
 - *-C* -> comment on what the key is for
 
 Here are our recommended input options for key generation.
+
 ::
     ssh-keygen -t rsa -b 4096 -f ~/.ssh/id_rsa_triton -C "triton key for ${USER}"
 
@@ -66,6 +70,7 @@ Copy public key to server
 -------------------------
 
 In order to use your key-pair to login to Triton, you first need to securely copy the desired *public key* to the machine with ``ssh-copy-id``. The script will also add the key to the ``~/.ssh/authorized_keys`` file on the server. You will be prompted to enter your Aalto password to initiate the secure copy of the file to Triton.
+
 ::
     ssh-copy-id -i ~/.ssh/id_rsa_triton.pub login_name@triton.aalto.fi
 
@@ -74,6 +79,7 @@ Login with SSH key
 -------------------
 
 To avoid having to type the decryption password, the *private key* it needs to be added to the ``ssh-agent`` with the command
+
 ::
     ssh-add ~/.ssh/id_rsa_triton
 
@@ -84,6 +90,7 @@ Config file: don't type so many options
 =======================================
 
 Remembering the full settings list for the server you are working on each time you log in can be tedious. A ssh ``config`` file allows you to store your preferred settings and map them to much simpler login commands. To create a new user-restricted ``config`` file
+
 ::
     touch ~/.ssh/config && chmod 600 ~/.ssh/config
 
@@ -95,6 +102,7 @@ For a new configuration, you need specify in ``config`` at minimum the
 - Hostname: the address of the server
 
 So for the simple Triton example, it would be
+
 ::
     # Configuration file for simplifying SSH logins
     #
@@ -104,6 +112,7 @@ So for the simple Triton example, it would be
         Hostname triton.aalto.fi
 
 and you would use ``ssh triton`` to log in. Any additional server configs can follow the first one and must start with declaring the configuration ``Host``.
+
 ::
     # general login server
     Host kosh
@@ -115,6 +124,7 @@ and you would use ``ssh triton`` to log in. Any additional server configs can fo
         Hostname brute.aalto.fi
 
 There are optional ssh settings that may be useful for your work, such as
+
 ::
         # Turn on X11 forwarding for Xterm graphics access
         ForwardX11 yes


### PR DESCRIPTION
I rewrote the page based on my notes while first setting up an account on Triton, focusing on the Linux/Mac user. There are a few things I'd like some feedback on.

- I'd like some help making the issue of typing in passwords even with ssh-keys clearer. Ubuntu 18.04 is storing it permanently for me, but standard ssh-agent only lasts for a single machine session.
- I'd like to propose adding a page that includes the SHA256 &/or randomart images for the various Linux servers so students don't breeze on by the WARNING when first logging into a machine.